### PR TITLE
ci: add dependabot config for daily updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+
+  - package-ecosystem: github-actions
+    directory: /.github/workflows
+    schedule:
+      interval: daily
+      timezone: Europe/Warsaw
+      time: "10:00"
+    labels: [dependencies, ci]
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+      timezone: Europe/Warsaw
+      time: "10:00"
+    labels: [dependencies, python, pip]


### PR DESCRIPTION
Enabled Dependabot to check for updates daily on GitHub Actions and Python packages, ensuring dependencies are kept up-to-date automatically.

The schedule is set for 10:00 AM Warsaw time for both ecosystems to maintain consistency. Commit includes labels for easier categorization of update PRs.